### PR TITLE
chore: remove SonarQube integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
 	alias(libs.plugins.kotlin.multiplatform.android.library).apply(false)
 	alias(libs.plugins.kotlin.multiplatform).apply(false)
-	alias(libs.plugins.sonarQube).apply(false)
 	alias(libs.plugins.googleKsp).apply(false)
 	alias(libs.plugins.mavenPublish).apply(false)
 }

--- a/decimal4kmp/build.gradle.kts
+++ b/decimal4kmp/build.gradle.kts
@@ -14,7 +14,6 @@ buildscript {
 plugins {
 	alias(libs.plugins.kotlin.multiplatform)
 	alias(libs.plugins.kotlin.multiplatform.android.library)
-	alias(libs.plugins.sonarQube)
 	alias(libs.plugins.googleKsp)
 	alias(libs.plugins.mavenPublish)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ kotlin = "2.3.0"
 android-minSdk = "24"
 #noinspection UnusedVersionCatalogEntry
 android-compileSdk = "36"
-sonarQube = "7.3.1.8318"
 ksp = "2.3.6"
 
 [libraries]
@@ -26,4 +25,3 @@ googleKsp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.35.0" }
 kotlin-multiplatform-android-library = { id = "com.android.kotlin.multiplatform.library", version.ref = "agp" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-sonarQube = { id = "org.sonarqube", version.ref = "sonarQube" }


### PR DESCRIPTION
Removes the SonarQube integration as part of the org-wide SonarQube decommissioning.

- Update `build.gradle.kts`
- Update `decimal4kmp/build.gradle.kts`
- Update `gradle/libs.versions.toml`

JaCoCo coverage config is left untouched. `backup.yml` stays on `@v3` (auto-generated by enablers-github-management).